### PR TITLE
fix: webview not showing via Go to Dashboard / Create New Story

### DIFF
--- a/app/renderer/modules/settings-modal.js
+++ b/app/renderer/modules/settings-modal.js
@@ -178,7 +178,7 @@ export function init() {
   });
 }
 
-export function updateWebviewModeUI() {
+function updateWebviewModeUI() {
   const mainContainer = document.querySelector('.main-container');
   if (state.headlessMode) {
     mainContainer.classList.remove('webview-active');

--- a/app/renderer/modules/settings-modal.js
+++ b/app/renderer/modules/settings-modal.js
@@ -178,7 +178,7 @@ export function init() {
   });
 }
 
-function updateWebviewModeUI() {
+export function updateWebviewModeUI() {
   const mainContainer = document.querySelector('.main-container');
   if (state.headlessMode) {
     mainContainer.classList.remove('webview-active');

--- a/app/renderer/modules/webview-polling.js
+++ b/app/renderer/modules/webview-polling.js
@@ -1,6 +1,7 @@
 // webview-polling.js — Story context detection, DOM relay, webview events, story change polling
 
 import { state, bus } from './state.js';
+import { updateWebviewModeUI } from './settings-modal.js';
 import { updateVisibility as updateStorySelectorVisibility } from './story-selector.js';
 import {
   webview, status,
@@ -444,12 +445,7 @@ export function init() {
     if (show) {
       state.headlessMode = false;
       window.powertool.setSceneSettings({ interfaceShowWebview: true, headlessMode: false });
-      // Toggle webview visibility CSS
-      const mainContainer = document.querySelector('.main-container');
-      if (mainContainer) {
-        mainContainer.classList.remove('headless-mode');
-        mainContainer.classList.add('webview-mode');
-      }
+      updateWebviewModeUI();
       bus.emit('settings:saved');
     }
   });

--- a/app/renderer/modules/webview-polling.js
+++ b/app/renderer/modules/webview-polling.js
@@ -1,7 +1,6 @@
 // webview-polling.js — Story context detection, DOM relay, webview events, story change polling
 
 import { state, bus } from './state.js';
-import { updateWebviewModeUI } from './settings-modal.js';
 import { updateVisibility as updateStorySelectorVisibility } from './story-selector.js';
 import {
   webview, status,
@@ -445,7 +444,12 @@ export function init() {
     if (show) {
       state.headlessMode = false;
       window.powertool.setSceneSettings({ interfaceShowWebview: true, headlessMode: false });
-      updateWebviewModeUI();
+      const mainContainer = document.querySelector('.main-container');
+      if (mainContainer) mainContainer.classList.add('webview-active');
+      const toggleBtn = document.getElementById('toggleWebviewBtn');
+      if (toggleBtn) toggleBtn.textContent = 'Hide Webview';
+      const overlay = document.getElementById('storySelectionOverlay');
+      if (overlay) overlay.classList.remove('visible');
       bus.emit('settings:saved');
     }
   });


### PR DESCRIPTION
## Summary
- The `headless:force-webview` bus handler used CSS classes `webview-mode` and `headless-mode` that don't exist in `main.css`
- Only `webview-active` has a rule that makes `.webview-container` visible
- As a result, clicking "Go to NovelAI Dashboard" or "Create New Story" in the story selector did nothing visually
- Fix: export `updateWebviewModeUI()` from `settings-modal.js` and call it from the handler, replacing the stale class manipulation

## Test plan
- [ ] Launch app in headless mode (default)
- [ ] Click "Go to NovelAI Dashboard" — webview appears, button reads "Hide Webview", overlay hides
- [ ] Click "Hide Webview" toggle — returns to headless editor
- [ ] Click "Create New Story" card — webview appears
- [ ] Toggle button path still works as before