### PR TITLE
feat: Prompt History with Favorites (#20) + Character Relationship Graph (#21)

### DIFF
--- a/app/db.js
+++ b/app/db.js
@@ -129,6 +129,19 @@ function createTables() {
       created_at INTEGER NOT NULL
     );
     CREATE INDEX IF NOT EXISTS idx_story_images_story ON story_images(story_id, paragraph_index);
+
+    CREATE TABLE IF NOT EXISTS prompt_history (
+      id TEXT PRIMARY KEY,
+      story_id TEXT NOT NULL,
+      prompt TEXT NOT NULL DEFAULT '',
+      negative_prompt TEXT DEFAULT '',
+      provider TEXT DEFAULT '',
+      model TEXT DEFAULT '',
+      is_favorite INTEGER DEFAULT 0,
+      created_at INTEGER NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_prompt_history_story
+      ON prompt_history(story_id, created_at DESC);
   `);
   console.log(`${LOG_PREFIX} Tables verified`);
 }
@@ -387,6 +400,51 @@ function resetVisualProfiles(storyId) {
   db.prepare('DELETE FROM visual_profiles WHERE story_id = ?').run(storyId);
 }
 
+// --- Prompt History ---
+
+function savePromptHistoryEntry(storyId, { id, prompt, negativePrompt, provider, model }) {
+  upsertStory(storyId, '');
+  const now = Date.now();
+  db.prepare(`
+    INSERT OR REPLACE INTO prompt_history
+      (id, story_id, prompt, negative_prompt, provider, model, is_favorite, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, 0, ?)
+  `).run(id, storyId, prompt || '', negativePrompt || '', provider || '', model || '', now);
+
+  // Prune oldest non-favorites beyond 50 per story
+  const excess = db.prepare(`
+    SELECT id FROM prompt_history
+    WHERE story_id = ? AND is_favorite = 0
+    ORDER BY created_at DESC
+    LIMIT -1 OFFSET 50
+  `).all(storyId);
+  if (excess.length > 0) {
+    const ids = excess.map(r => r.id);
+    db.prepare(`DELETE FROM prompt_history WHERE id IN (${ids.map(() => '?').join(',')})`)
+      .run(...ids);
+  }
+}
+
+function listPromptHistory(storyId) {
+  return db.prepare(`
+    SELECT * FROM prompt_history
+    WHERE story_id = ?
+    ORDER BY is_favorite DESC, created_at DESC
+  `).all(storyId);
+}
+
+function togglePromptFavorite(storyId, id) {
+  db.prepare(`
+    UPDATE prompt_history
+    SET is_favorite = CASE WHEN is_favorite = 1 THEN 0 ELSE 1 END
+    WHERE story_id = ? AND id = ?
+  `).run(storyId, id);
+}
+
+function deletePromptHistoryEntry(storyId, id) {
+  db.prepare('DELETE FROM prompt_history WHERE story_id = ? AND id = ?').run(storyId, id);
+}
+
 function close() {
   if (db) {
     console.log(`${LOG_PREFIX} Closing database`);
@@ -409,5 +467,6 @@ module.exports = {
   getTimelineState, setTimelineState,
   getStoryText, setStoryText,
   getStoryImages, setStoryImage, removeStoryImage, removeAllStoryImages,
+  savePromptHistoryEntry, listPromptHistory, togglePromptFavorite, deletePromptHistoryEntry,
   loadAllStoryData, migrateFromStore,
 };

--- a/app/main.js
+++ b/app/main.js
@@ -1372,6 +1372,19 @@ ipcMain.handle('story-images:get-image-data', async (event, storyId, imageId) =>
   }
 });
 
+// Prompt History
+ipcMain.handle('prompt-history:save', (_, { storyId, entry }) =>
+  db.savePromptHistoryEntry(storyId, entry));
+
+ipcMain.handle('prompt-history:list', (_, { storyId }) =>
+  db.listPromptHistory(storyId));
+
+ipcMain.handle('prompt-history:toggle-favorite', (_, { storyId, id }) =>
+  db.togglePromptFavorite(storyId, id));
+
+ipcMain.handle('prompt-history:delete', (_, { storyId, id }) =>
+  db.deletePromptHistoryEntry(storyId, id));
+
 // Text actions — AI-powered text operations for the headless editor
 ipcMain.handle('text-action', async (event, { type, text, storyId }) => {
   try {

--- a/app/preload.js
+++ b/app/preload.js
@@ -127,6 +127,12 @@ contextBridge.exposeInMainWorld('powertool', {
   // Text actions
   textAction: (type, text, storyId) => ipcRenderer.invoke('text-action', { type, text, storyId }),
 
+  // Prompt History
+  promptHistorySave:           (storyId, entry) => ipcRenderer.invoke('prompt-history:save', { storyId, entry }),
+  promptHistoryList:           (storyId)        => ipcRenderer.invoke('prompt-history:list', { storyId }),
+  promptHistoryToggleFavorite: (storyId, id)    => ipcRenderer.invoke('prompt-history:toggle-favorite', { storyId, id }),
+  promptHistoryDelete:         (storyId, id)    => ipcRenderer.invoke('prompt-history:delete', { storyId, id }),
+
   // Script Manager
   scriptMgrListScripts: () => ipcRenderer.invoke('script-mgr:list-scripts'),
   scriptMgrEnableScript: (name) => ipcRenderer.invoke('script-mgr:enable-script', name),

--- a/app/renderer/index.html
+++ b/app/renderer/index.html
@@ -975,6 +975,7 @@
           <button id="rpgGenerateAllPortraits" class="rpg-action-btn" title="Generate portraits for characters without one. Shift+click to regenerate all.">
             Generate Portraits
           </button>
+          <button id="graphToggleBtn" class="rpg-action-btn u-hidden" title="Character relationship graph">Graph</button>
         </div>
         <label class="rpg-option-label"><input type="checkbox" id="rpgForceReEnrich"> Re-enrich all descriptions</label>
 
@@ -997,6 +998,9 @@
 
         <!-- Persona Cast View (non-LitRPG) -->
         <div class="u-hidden" id="rpgCastView"></div>
+
+        <!-- Relationship Graph -->
+        <div id="relationshipGraphContainer" class="u-hidden relationship-graph-container"></div>
 
         <!-- Party View -->
         <details class="lore-section" id="rpgPartySection" open>

--- a/app/renderer/index.html
+++ b/app/renderer/index.html
@@ -566,6 +566,7 @@
         <div class="scene-sub-tabs" id="sceneSubTabs">
           <button class="scene-sub-tab active" id="storyboardSubTab">Storyboard</button>
           <button class="scene-sub-tab" id="timelineSubTab">Timeline</button>
+          <button class="scene-sub-tab" id="historySubTab">History</button>
         </div>
         <div id="storyboardView">
         <div id="imageContainer">
@@ -626,6 +627,13 @@
             <span id="timelineScanStatus" class="scan-status" style="color:#888;font-size:11px;margin-left:8px;"></span>
           </div>
           <div id="timelineList" style="margin-top:12px;"></div>
+        </div>
+
+        <div class="u-hidden" id="historyView">
+          <div class="history-toolbar">
+            <button id="historyFavFilterBtn" class="history-filter-btn">&#9733; Favorites</button>
+          </div>
+          <div id="historyList" class="history-list"></div>
         </div>
 
       </div>

--- a/app/renderer/index.html
+++ b/app/renderer/index.html
@@ -1695,6 +1695,7 @@
     import { init as initMediaGallery } from './modules/media-gallery.js';
     import { init as initHeadlessSync } from './modules/headless-sync.js';
     import { init as initTimeline } from './modules/scene-timeline.js';
+    import { init as initPromptHistory } from './modules/prompt-history.js';
     import { init as initPortraitQueue } from './modules/portrait-queue.js';
     import { init as initStorySelector } from './modules/story-selector.js';
     import { init as initScriptPanel } from './modules/script-panel.js';
@@ -1715,6 +1716,7 @@
     initMediaGallery();
     initHeadlessSync();
     initTimeline();
+    initPromptHistory();
   </script>
 
   <!-- Old inline script removed; code moved to ./modules/ -->

--- a/app/renderer/modules/dom-refs.js
+++ b/app/renderer/modules/dom-refs.js
@@ -588,8 +588,12 @@ export const portraitProviderCostWarning = document.getElementById('portraitProv
 // Scene sub-tab elements
 export const storyboardSubTab = document.getElementById('storyboardSubTab');
 export const timelineSubTab = document.getElementById('timelineSubTab');
+export const historySubTab = document.getElementById('historySubTab');
 export const storyboardView = document.getElementById('storyboardView');
 export const timelineView = document.getElementById('timelineView');
+export const historyView = document.getElementById('historyView');
+export const historyFavFilterBtn = document.getElementById('historyFavFilterBtn');
+export const historyList = document.getElementById('historyList');
 export const timelineScanBtn = document.getElementById('timelineScanBtn');
 export const timelineScanStatus = document.getElementById('timelineScanStatus');
 export const timelineList = document.getElementById('timelineList');

--- a/app/renderer/modules/dom-refs.js
+++ b/app/renderer/modules/dom-refs.js
@@ -581,6 +581,8 @@ export const dynamicCategoriesStyle = document.getElementById('dynamic-categorie
 
 // Portrait settings elements
 export const rpgGenerateAllPortraits = document.getElementById('rpgGenerateAllPortraits');
+export const graphToggleBtn = document.getElementById('graphToggleBtn');
+export const relationshipGraphContainer = document.getElementById('relationshipGraphContainer');
 export const autoGeneratePortraitsCheckbox = document.getElementById('autoGeneratePortraits');
 export const portraitProviderSelect = document.getElementById('portraitProvider');
 export const portraitProviderCostWarning = document.getElementById('portraitProviderCostWarning');

--- a/app/renderer/modules/litrpg-panel.js
+++ b/app/renderer/modules/litrpg-panel.js
@@ -31,6 +31,7 @@ import {
   rpgAlbumLightbox, rpgAlbumLightboxImg, rpgAlbumPrev, rpgAlbumNext,
   rpgAlbumCounter, rpgAlbumSetActive, rpgAlbumDelete, rpgAlbumClose,
   rpgGenerateAllPortraits,
+  graphToggleBtn, relationshipGraphContainer,
   webview,
 } from './dom-refs.js';
 import { escapeHtml, showToast } from './utils.js';
@@ -137,6 +138,8 @@ function applyChangeToChar(char, scoredChange) {
 // STATE HELPERS
 // =========================================================================
 
+let graphViewActive = false;
+
 function getRpgState() {
   return state.litrpgState || {};
 }
@@ -189,6 +192,13 @@ export function refreshRpgUI() {
   if (rpgSyncLorebookBtn) rpgSyncLorebookBtn.disabled = !rpg.enabled;
   if (rpgReverseSyncBtn) rpgReverseSyncBtn.disabled = !rpg.enabled;
 
+  // Graph toggle button — only visible when LitRPG is enabled with characters
+  if (graphToggleBtn) {
+    const hasChars = Object.keys(rpg.characters || {}).length > 0;
+    graphToggleBtn.classList.toggle('u-hidden', !(rpg.enabled && hasChars));
+    graphToggleBtn.textContent = graphViewActive ? 'List' : 'Graph';
+  }
+
   // Settings persistence (Phase 5A)
   if (rpgAutoScan) rpgAutoScan.checked = rpg.autoScan !== false;
   if (rpgAutoSync) rpgAutoSync.checked = !!rpg.autoSync;
@@ -201,10 +211,14 @@ export function refreshRpgUI() {
     rpgInventorySection, rpgCurrencySection, rpgStatusSection,
     rpgFactionsSection, rpgClassesSection, rpgRacesSection,
   ];
+  const hideRpgSections = !isLitRPG || graphViewActive;
   for (const el of rpgOnlySections) {
-    if (el) el.classList.toggle('u-hidden', !isLitRPG);
+    if (el) el.classList.toggle('u-hidden', hideRpgSections);
   }
-  if (rpgCastView) rpgCastView.classList.toggle('u-hidden', isLitRPG);
+  if (rpgCastView) rpgCastView.classList.toggle('u-hidden', isLitRPG || graphViewActive);
+  if (relationshipGraphContainer) {
+    relationshipGraphContainer.classList.toggle('u-hidden', !graphViewActive);
+  }
 
   if (isLitRPG) {
     // Party view
@@ -2432,6 +2446,11 @@ function setupIPCListeners() {
     state.litrpgState = newState;
     state.litrpgEnabled = newState.enabled;
     refreshRpgUI();
+    if (graphViewActive && relationshipGraphContainer) {
+      import('./relationship-graph.js').then(({ renderRelationshipGraph }) => {
+        renderRelationshipGraph(relationshipGraphContainer, newState);
+      });
+    }
 
     // Emit events for portrait queue
     const updatedChars = getRpgState()?.characters;
@@ -2491,6 +2510,7 @@ function setupIPCListeners() {
 // =========================================================================
 
 function onStorySwitch() {
+  graphViewActive = false;
   const rpg = state.litrpgState || {};
   state.litrpgEnabled = !!rpg.enabled;
   refreshRpgUI();
@@ -2629,6 +2649,24 @@ export function init() {
         rpgData: char,
       }));
       enqueuePortraits(chars, { regenerate });
+    });
+  }
+
+  // Graph toggle
+  if (graphToggleBtn) {
+    graphToggleBtn.addEventListener('click', () => {
+      graphViewActive = !graphViewActive;
+      graphToggleBtn.textContent = graphViewActive ? 'List' : 'Graph';
+      if (graphViewActive && relationshipGraphContainer) {
+        import('./relationship-graph.js').then(({ renderRelationshipGraph }) => {
+          renderRelationshipGraph(relationshipGraphContainer, getRpgState());
+        });
+      } else if (relationshipGraphContainer) {
+        import('./relationship-graph.js').then(({ clearRelationshipGraph }) => {
+          clearRelationshipGraph(relationshipGraphContainer);
+        });
+      }
+      refreshRpgUI();
     });
   }
 

--- a/app/renderer/modules/lore-creator.js
+++ b/app/renderer/modules/lore-creator.js
@@ -28,7 +28,7 @@ import {
   loreAddCategoryForm, loreNewCategoryName, loreNewCategoryColor,
   loreAddCategoryConfirm, loreAddCategoryCancel, dynamicCategoriesStyle,
   loreOptProfile, loreOptimizeAllBtn, loreDiscoverFieldsBtn, loreOptStatus,
-  storyboardSubTab, timelineSubTab, storyboardView, timelineView,
+  storyboardSubTab, timelineSubTab, historySubTab, storyboardView, timelineView, historyView,
 } from './dom-refs.js';
 import { escapeHtml, showToast, timeAgo } from './utils.js';
 import { parseMetadataClient } from './metadata.js';
@@ -2409,15 +2409,28 @@ export function init() {
   storyboardSubTab?.addEventListener('click', () => {
     storyboardSubTab.classList.add('active');
     timelineSubTab.classList.remove('active');
+    historySubTab.classList.remove('active');
     storyboardView.classList.remove('u-hidden');
     timelineView.classList.add('u-hidden');
+    historyView.classList.add('u-hidden');
   });
   timelineSubTab?.addEventListener('click', () => {
     timelineSubTab.classList.add('active');
     storyboardSubTab.classList.remove('active');
+    historySubTab.classList.remove('active');
     storyboardView.classList.add('u-hidden');
     timelineView.classList.remove('u-hidden');
+    historyView.classList.add('u-hidden');
     import('./scene-timeline.js').then(m => m.refreshTimelineUI && m.refreshTimelineUI());
+  });
+  historySubTab?.addEventListener('click', () => {
+    historySubTab.classList.add('active');
+    storyboardSubTab.classList.remove('active');
+    timelineSubTab.classList.remove('active');
+    storyboardView.classList.add('u-hidden');
+    timelineView.classList.add('u-hidden');
+    historyView.classList.remove('u-hidden');
+    import('./prompt-history.js').then(m => m.renderHistory && m.renderHistory());
   });
 
   // --- Delegated event listeners for lore card lists ---

--- a/app/renderer/modules/prompt-history.js
+++ b/app/renderer/modules/prompt-history.js
@@ -1,0 +1,146 @@
+// prompt-history.js — Prompt History with Favorites for the Scene panel
+
+import { state, bus } from './state.js';
+import { showToast, timeAgo } from './utils.js';
+import { promptDisplay, historyFavFilterBtn, historyList, storyboardSubTab, historySubTab, historyView, storyboardView, timelineView } from './dom-refs.js';
+
+let favoritesOnly = false;
+
+export function init() {
+  bus.on('image:generated', ({ storyId, meta }) => autoSave(storyId, meta));
+
+  historyFavFilterBtn?.addEventListener('click', () => {
+    favoritesOnly = !favoritesOnly;
+    historyFavFilterBtn.classList.toggle('active', favoritesOnly);
+    renderHistory();
+  });
+}
+
+async function autoSave(storyId, meta) {
+  if (!state.headlessMode) return;
+  if (storyId !== state.currentStoryId) return;
+  const prompt = state.prompt?.display || '';
+  if (!prompt) return;
+
+  const id = 'ph-' + crypto.randomUUID();
+  try {
+    await window.powertool.promptHistorySave(storyId, {
+      id,
+      prompt,
+      negativePrompt: state.prompt?.negative || '',
+      provider: meta?.provider || '',
+      model: meta?.model || '',
+    });
+  } catch (e) {
+    console.error('[PromptHistory] autoSave error:', e);
+  }
+}
+
+export async function renderHistory() {
+  if (!historyList) return;
+  const storyId = state.currentStoryId;
+  if (!storyId) {
+    historyList.innerHTML = '<p style="color:#666;font-size:12px;padding:8px 0;">No story loaded.</p>';
+    return;
+  }
+
+  let entries;
+  try {
+    entries = await window.powertool.promptHistoryList(storyId);
+  } catch (e) {
+    historyList.innerHTML = '<p style="color:#666;font-size:12px;padding:8px 0;">Failed to load history.</p>';
+    return;
+  }
+
+  if (favoritesOnly) entries = entries.filter(e => e.is_favorite);
+
+  if (!entries.length) {
+    historyList.innerHTML = '<p style="color:#666;font-size:12px;padding:8px 0;">No history yet. Generate an image to start.</p>';
+    return;
+  }
+
+  historyList.innerHTML = entries.map(entry => buildCard(entry)).join('');
+
+  historyList.querySelectorAll('.history-star').forEach(btn => {
+    btn.addEventListener('click', () => onToggleFavorite(btn.dataset.id));
+  });
+  historyList.querySelectorAll('.history-reuse-btn').forEach(btn => {
+    btn.addEventListener('click', () => onReuse(btn.dataset.id, entries));
+  });
+  historyList.querySelectorAll('.history-del-btn').forEach(btn => {
+    btn.addEventListener('click', () => onDelete(btn.dataset.id));
+  });
+}
+
+function buildCard(entry) {
+  const truncated = entry.prompt.length > 120
+    ? entry.prompt.slice(0, 120) + '…'
+    : entry.prompt;
+  const starClass = entry.is_favorite ? 'history-star fav' : 'history-star';
+  const starGlyph = entry.is_favorite ? '★' : '☆';
+  const meta = [entry.provider, entry.model].filter(Boolean).join(' / ');
+  const age = timeAgo(entry.created_at);
+  return `
+    <div class="history-card" data-id="${entry.id}">
+      <div class="history-card-header">
+        <span class="history-prompt-text">${escapeHtml(truncated)}</span>
+        <button class="${starClass}" data-id="${entry.id}" title="Toggle favorite">${starGlyph}</button>
+      </div>
+      <div class="history-card-footer">
+        <span class="history-meta">${escapeHtml(meta)}${meta ? ' · ' : ''}${age}</span>
+        <button class="history-reuse-btn" data-id="${entry.id}">Reuse</button>
+        <button class="history-del-btn" data-id="${entry.id}">Delete</button>
+      </div>
+    </div>`;
+}
+
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+async function onToggleFavorite(id) {
+  const storyId = state.currentStoryId;
+  if (!storyId) return;
+  try {
+    await window.powertool.promptHistoryToggleFavorite(storyId, id);
+    await renderHistory();
+  } catch (e) {
+    console.error('[PromptHistory] toggleFavorite error:', e);
+  }
+}
+
+function onReuse(id, entries) {
+  const entry = entries.find(e => e.id === id);
+  if (!entry) return;
+  // Load prompt into state and the display textarea
+  state.prompt.display = entry.prompt;
+  state.prompt.negativeEdited = false;
+  if (entry.negativePrompt) {
+    state.prompt.negative = entry.negativePrompt;
+  }
+  if (promptDisplay) promptDisplay.value = entry.prompt;
+
+  // Switch back to Storyboard sub-tab
+  if (historySubTab) historySubTab.classList.remove('active');
+  if (storyboardSubTab) storyboardSubTab.classList.add('active');
+  if (historyView) historyView.classList.add('u-hidden');
+  if (timelineView) timelineView.classList.add('u-hidden');
+  if (storyboardView) storyboardView.classList.remove('u-hidden');
+
+  showToast('Prompt loaded', 2000);
+}
+
+async function onDelete(id) {
+  const storyId = state.currentStoryId;
+  if (!storyId) return;
+  try {
+    await window.powertool.promptHistoryDelete(storyId, id);
+    await renderHistory();
+  } catch (e) {
+    console.error('[PromptHistory] delete error:', e);
+  }
+}

--- a/app/renderer/modules/prompt-history.js
+++ b/app/renderer/modules/prompt-history.js
@@ -2,17 +2,33 @@
 
 import { state, bus } from './state.js';
 import { showToast, timeAgo } from './utils.js';
-import { promptDisplay, historyFavFilterBtn, historyList, storyboardSubTab, historySubTab, historyView, storyboardView, timelineView } from './dom-refs.js';
+import { promptDisplay, negativePromptDisplay, historyFavFilterBtn, historyList, storyboardSubTab, historySubTab, historyView, storyboardView, timelineView } from './dom-refs.js';
 
 let favoritesOnly = false;
+let currentEntries = [];
 
 export function init() {
+  // Hide history tab in webview mode
+  if (!state.headlessMode && historySubTab) {
+    historySubTab.classList.add('u-hidden');
+  }
+
   bus.on('image:generated', ({ storyId, meta }) => autoSave(storyId, meta));
 
   historyFavFilterBtn?.addEventListener('click', () => {
     favoritesOnly = !favoritesOnly;
     historyFavFilterBtn.classList.toggle('active', favoritesOnly);
     renderHistory();
+  });
+
+  // Event delegation for all card actions
+  historyList?.addEventListener('click', (e) => {
+    const btn = e.target.closest('[data-action]');
+    if (!btn) return;
+    const { action, id } = btn.dataset;
+    if (action === 'star') onToggleFavorite(id);
+    else if (action === 'reuse') onReuse(id);
+    else if (action === 'delete') onDelete(id);
   });
 }
 
@@ -40,7 +56,7 @@ export async function renderHistory() {
   if (!historyList) return;
   const storyId = state.currentStoryId;
   if (!storyId) {
-    historyList.innerHTML = '<p style="color:#666;font-size:12px;padding:8px 0;">No story loaded.</p>';
+    historyList.innerHTML = '<p class="history-empty">No story loaded.</p>';
     return;
   }
 
@@ -48,28 +64,20 @@ export async function renderHistory() {
   try {
     entries = await window.powertool.promptHistoryList(storyId);
   } catch (e) {
-    historyList.innerHTML = '<p style="color:#666;font-size:12px;padding:8px 0;">Failed to load history.</p>';
+    historyList.innerHTML = '<p class="history-empty">Failed to load history.</p>';
     return;
   }
 
   if (favoritesOnly) entries = entries.filter(e => e.is_favorite);
 
+  currentEntries = entries;
+
   if (!entries.length) {
-    historyList.innerHTML = '<p style="color:#666;font-size:12px;padding:8px 0;">No history yet. Generate an image to start.</p>';
+    historyList.innerHTML = '<p class="history-empty">No history yet. Generate an image to start.</p>';
     return;
   }
 
   historyList.innerHTML = entries.map(entry => buildCard(entry)).join('');
-
-  historyList.querySelectorAll('.history-star').forEach(btn => {
-    btn.addEventListener('click', () => onToggleFavorite(btn.dataset.id));
-  });
-  historyList.querySelectorAll('.history-reuse-btn').forEach(btn => {
-    btn.addEventListener('click', () => onReuse(btn.dataset.id, entries));
-  });
-  historyList.querySelectorAll('.history-del-btn').forEach(btn => {
-    btn.addEventListener('click', () => onDelete(btn.dataset.id));
-  });
 }
 
 function buildCard(entry) {
@@ -84,12 +92,12 @@ function buildCard(entry) {
     <div class="history-card" data-id="${entry.id}">
       <div class="history-card-header">
         <span class="history-prompt-text">${escapeHtml(truncated)}</span>
-        <button class="${starClass}" data-id="${entry.id}" title="Toggle favorite">${starGlyph}</button>
+        <button class="${starClass}" data-action="star" data-id="${entry.id}" title="Toggle favorite">${starGlyph}</button>
       </div>
       <div class="history-card-footer">
         <span class="history-meta">${escapeHtml(meta)}${meta ? ' · ' : ''}${age}</span>
-        <button class="history-reuse-btn" data-id="${entry.id}">Reuse</button>
-        <button class="history-del-btn" data-id="${entry.id}">Delete</button>
+        <button class="history-reuse-btn" data-action="reuse" data-id="${entry.id}">Reuse</button>
+        <button class="history-del-btn" data-action="delete" data-id="${entry.id}">Delete</button>
       </div>
     </div>`;
 }
@@ -113,14 +121,15 @@ async function onToggleFavorite(id) {
   }
 }
 
-function onReuse(id, entries) {
-  const entry = entries.find(e => e.id === id);
+function onReuse(id) {
+  const entry = currentEntries.find(e => e.id === id);
   if (!entry) return;
-  // Load prompt into state and the display textarea
+  // Load prompt into state and the display textareas
   state.prompt.display = entry.prompt;
   state.prompt.negativeEdited = false;
-  if (entry.negativePrompt) {
-    state.prompt.negative = entry.negativePrompt;
+  if (entry.negative_prompt) {
+    state.prompt.negative = entry.negative_prompt;
+    if (negativePromptDisplay) negativePromptDisplay.value = entry.negative_prompt;
   }
   if (promptDisplay) promptDisplay.value = entry.prompt;
 

--- a/app/renderer/modules/relationship-graph.js
+++ b/app/renderer/modules/relationship-graph.js
@@ -1,0 +1,363 @@
+// relationship-graph.js — SVG radial character relationship graph for the LitRPG Cast panel
+
+const RINGS = {
+  party:    { r: 90,  color: '#4fc3f7', edgeColor: '#4fc3f7' },
+  friendly: { r: 170, color: '#81c784', edgeColor: '#81c784' },
+  neutral:  { r: 250, color: '#bbb',    edgeColor: '#555'    },
+  hostile:  { r: 330, color: '#e57373', edgeColor: '#e57373' },
+};
+
+const CENTER_X = 300;
+const CENTER_Y = 300;
+const VIEWBOX = '0 0 600 600';
+const PROTAGONIST_R = 18;
+const CHAR_R = 11;
+const HUB_R = 7;
+
+function getRing(char) {
+  if (char.isPartyMember || char.partyRole === 'party-member' ||
+      char.partyRole === 'companion' || char.partyRole === 'summon' ||
+      char.partyRole === 'pet' || char.partyRole === 'mount') {
+    return 'party';
+  }
+  const d = (char.disposition || '').toLowerCase();
+  const nr = (char.npcRole || '').toLowerCase();
+  if (d === 'friendly' || nr === 'ally' || nr === 'mentor') return 'friendly';
+  if (d === 'hostile' || nr === 'rival' || nr === 'boss') return 'hostile';
+  if (d === 'neutral') return 'neutral';
+  return 'neutral';
+}
+
+function placeNodes(chars) {
+  const rings = { party: [], friendly: [], neutral: [], hostile: [] };
+  for (const char of chars) {
+    rings[getRing(char)].push(char);
+  }
+  const nodes = [];
+  for (const [ringName, members] of Object.entries(rings)) {
+    const { r, color } = RINGS[ringName];
+    const count = members.length;
+    members.forEach((char, i) => {
+      const angle = count === 1 ? -Math.PI / 2 : (2 * Math.PI * i / count) - Math.PI / 2;
+      nodes.push({
+        id: char.id,
+        name: char.name,
+        x: CENTER_X + r * Math.cos(angle),
+        y: CENTER_Y + r * Math.sin(angle),
+        color,
+        ring: ringName,
+        char,
+      });
+    });
+  }
+  return nodes;
+}
+
+function buildFactionHubs(nodes) {
+  const factionMap = new Map();
+  for (const node of nodes) {
+    const f = node.char.faction;
+    if (!f) continue;
+    const key = f.toLowerCase();
+    if (!factionMap.has(key)) factionMap.set(key, { name: f, members: [] });
+    factionMap.get(key).members.push(node);
+  }
+  const hubs = [];
+  for (const { name, members } of factionMap.values()) {
+    if (members.length < 2) continue;
+    const cx = members.reduce((s, n) => s + n.x, 0) / members.length;
+    const cy = members.reduce((s, n) => s + n.y, 0) / members.length;
+    // Nudge hub toward center slightly so it doesn't sit on top of nodes
+    const nx = cx + (CENTER_X - cx) * 0.3;
+    const ny = cy + (CENTER_Y - cy) * 0.3;
+    hubs.push({ name, cx: nx, cy: ny, members });
+  }
+  return hubs;
+}
+
+function escapeHtml(str) {
+  return String(str || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function midpoint(x1, y1, x2, y2) {
+  return { x: (x1 + x2) / 2, y: (y1 + y2) / 2 };
+}
+
+export function renderRelationshipGraph(container, litrpgState) {
+  container.innerHTML = '';
+
+  const chars = Object.values(litrpgState.characters || {});
+  if (!chars.length) {
+    container.innerHTML = '<p style="color:#666;font-size:12px;padding:16px;text-align:center;">No characters found. Run a LitRPG scan first.</p>';
+    return;
+  }
+
+  // Build SVG
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('viewBox', VIEWBOX);
+  svg.setAttribute('width', '100%');
+  svg.setAttribute('height', '100%');
+  svg.style.cssText = 'display:block;user-select:none;';
+
+  // Inner transform group (for pan/zoom)
+  const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+  g.setAttribute('id', 'rg-inner');
+  svg.appendChild(g);
+
+  const nodes = placeNodes(chars);
+  const factionHubs = buildFactionHubs(nodes);
+
+  // --- Edges: character → protagonist ---
+  const edgeGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+  edgeGroup.setAttribute('id', 'rg-edges');
+  g.appendChild(edgeGroup);
+
+  for (const node of nodes) {
+    const ring = RINGS[node.ring];
+    const isHostile = node.ring === 'hostile';
+    const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+    line.setAttribute('x1', CENTER_X);
+    line.setAttribute('y1', CENTER_Y);
+    line.setAttribute('x2', node.x);
+    line.setAttribute('y2', node.y);
+    line.setAttribute('stroke', ring.edgeColor);
+    line.setAttribute('stroke-width', '1');
+    line.setAttribute('stroke-opacity', '0.4');
+    if (isHostile) line.setAttribute('stroke-dasharray', '4 3');
+    line.dataset.nodeId = node.id;
+    line.classList.add('rg-edge');
+    edgeGroup.appendChild(line);
+
+    // Edge label: npcRole or partyRole
+    const label = node.char.npcRole || (node.char.partyRole !== 'npc' ? node.char.partyRole : null);
+    if (label) {
+      const mid = midpoint(CENTER_X, CENTER_Y, node.x, node.y);
+      const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+      text.setAttribute('x', mid.x);
+      text.setAttribute('y', mid.y - 4);
+      text.setAttribute('text-anchor', 'middle');
+      text.setAttribute('font-size', '8');
+      text.setAttribute('fill', ring.edgeColor);
+      text.setAttribute('fill-opacity', '0.6');
+      text.textContent = label;
+      text.classList.add('rg-edge-label');
+      text.dataset.nodeId = node.id;
+      edgeGroup.appendChild(text);
+    }
+  }
+
+  // --- Faction hub edges (dashed, thin) ---
+  for (const hub of factionHubs) {
+    for (const member of hub.members) {
+      const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+      line.setAttribute('x1', hub.cx);
+      line.setAttribute('y1', hub.cy);
+      line.setAttribute('x2', member.x);
+      line.setAttribute('y2', member.y);
+      line.setAttribute('stroke', '#888');
+      line.setAttribute('stroke-width', '0.8');
+      line.setAttribute('stroke-dasharray', '2 2');
+      line.setAttribute('stroke-opacity', '0.4');
+      g.appendChild(line);
+    }
+  }
+
+  // --- Character nodes ---
+  const nodeGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+  nodeGroup.setAttribute('id', 'rg-nodes');
+  g.appendChild(nodeGroup);
+
+  for (const node of nodes) {
+    const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+    circle.setAttribute('cx', node.x);
+    circle.setAttribute('cy', node.y);
+    circle.setAttribute('r', CHAR_R);
+    circle.setAttribute('fill', node.color);
+    circle.setAttribute('stroke', '#1a1a2e');
+    circle.setAttribute('stroke-width', '2');
+    circle.style.cursor = 'pointer';
+    circle.dataset.nodeId = node.id;
+    circle.classList.add('rg-node');
+    nodeGroup.appendChild(circle);
+
+    // Name label
+    const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+    text.setAttribute('x', node.x);
+    text.setAttribute('y', node.y + CHAR_R + 10);
+    text.setAttribute('text-anchor', 'middle');
+    text.setAttribute('font-size', '9');
+    text.setAttribute('fill', '#ccc');
+    text.textContent = node.name;
+    nodeGroup.appendChild(text);
+  }
+
+  // --- Faction hub nodes ---
+  for (const hub of factionHubs) {
+    const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+    circle.setAttribute('cx', hub.cx);
+    circle.setAttribute('cy', hub.cy);
+    circle.setAttribute('r', HUB_R);
+    circle.setAttribute('fill', 'none');
+    circle.setAttribute('stroke', '#888');
+    circle.setAttribute('stroke-width', '1.5');
+    circle.setAttribute('stroke-dasharray', '3 2');
+    g.appendChild(circle);
+
+    const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+    text.setAttribute('x', hub.cx);
+    text.setAttribute('y', hub.cy - HUB_R - 3);
+    text.setAttribute('text-anchor', 'middle');
+    text.setAttribute('font-size', '8');
+    text.setAttribute('fill', '#888');
+    text.textContent = hub.name;
+    g.appendChild(text);
+  }
+
+  // --- Protagonist node (drawn last, on top) ---
+  const protCircle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+  protCircle.setAttribute('cx', CENTER_X);
+  protCircle.setAttribute('cy', CENTER_Y);
+  protCircle.setAttribute('r', PROTAGONIST_R);
+  protCircle.setAttribute('fill', '#e94560');
+  protCircle.setAttribute('stroke', '#fff');
+  protCircle.setAttribute('stroke-width', '2');
+  g.appendChild(protCircle);
+
+  const protLabel = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+  protLabel.setAttribute('x', CENTER_X);
+  protLabel.setAttribute('y', CENTER_Y + PROTAGONIST_R + 12);
+  protLabel.setAttribute('text-anchor', 'middle');
+  protLabel.setAttribute('font-size', '10');
+  protLabel.setAttribute('fill', '#e94560');
+  protLabel.textContent = 'Protagonist';
+  g.appendChild(protLabel);
+
+  container.appendChild(svg);
+
+  // --- Tooltip ---
+  const tooltip = document.createElement('div');
+  tooltip.className = 'rg-tooltip u-hidden';
+  container.appendChild(tooltip);
+
+  // --- Interaction: hover tooltip ---
+  for (const circle of nodeGroup.querySelectorAll('.rg-node')) {
+    circle.addEventListener('mouseenter', (e) => {
+      const nodeId = e.currentTarget.dataset.nodeId;
+      const node = nodes.find(n => n.id === nodeId);
+      if (!node) return;
+      const c = node.char;
+      const lines = [
+        `<strong>${escapeHtml(c.name)}</strong>`,
+        c.class ? `${escapeHtml(c.class)}${c.level ? ' Lv.' + c.level : ''}` : null,
+        c.faction ? `Faction: ${escapeHtml(c.faction)}` : null,
+        c.npcRelationship ? escapeHtml(c.npcRelationship) : null,
+      ].filter(Boolean);
+      tooltip.innerHTML = lines.join('<br>');
+      tooltip.classList.remove('u-hidden');
+
+      // Position relative to container
+      const cx = e.currentTarget.getAttribute('cx') * 1;
+      const cy = e.currentTarget.getAttribute('cy') * 1;
+      // Approximate SVG→screen transform (viewBox 600×600, container fills 100%)
+      const scaleX = container.clientWidth / 600;
+      const scaleY = container.clientHeight / 600;
+      let tx = cx * scaleX + 16;
+      let ty = cy * scaleY - 16;
+      if (tx + 160 > container.clientWidth) tx = cx * scaleX - 160;
+      tooltip.style.left = tx + 'px';
+      tooltip.style.top = ty + 'px';
+    });
+    circle.addEventListener('mouseleave', () => {
+      tooltip.classList.add('u-hidden');
+    });
+  }
+
+  // --- Interaction: click to highlight node's edges ---
+  let selectedNodeId = null;
+  for (const circle of nodeGroup.querySelectorAll('.rg-node')) {
+    circle.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const nodeId = e.currentTarget.dataset.nodeId;
+      if (selectedNodeId === nodeId) {
+        clearHighlight(edgeGroup, nodeGroup);
+        selectedNodeId = null;
+      } else {
+        selectedNodeId = nodeId;
+        highlightNode(nodeId, edgeGroup, nodeGroup);
+      }
+    });
+  }
+  svg.addEventListener('click', () => {
+    if (selectedNodeId) {
+      clearHighlight(edgeGroup, nodeGroup);
+      selectedNodeId = null;
+    }
+  });
+
+  // --- Pan + Zoom ---
+  let panActive = false;
+  let panStart = { x: 0, y: 0 };
+  let translate = { x: 0, y: 0 };
+  let scale = 1;
+
+  svg.addEventListener('mousedown', (e) => {
+    if (e.target.classList.contains('rg-node')) return;
+    panActive = true;
+    panStart = { x: e.clientX - translate.x, y: e.clientY - translate.y };
+    svg.style.cursor = 'grabbing';
+  });
+  window.addEventListener('mousemove', (e) => {
+    if (!panActive) return;
+    translate.x = e.clientX - panStart.x;
+    translate.y = e.clientY - panStart.y;
+    applyTransform(g, translate, scale);
+  });
+  window.addEventListener('mouseup', () => {
+    if (panActive) { panActive = false; svg.style.cursor = ''; }
+  });
+  svg.addEventListener('wheel', (e) => {
+    e.preventDefault();
+    const delta = e.deltaY > 0 ? -0.1 : 0.1;
+    scale = Math.max(0.5, Math.min(2.0, scale + delta));
+    applyTransform(g, translate, scale);
+  }, { passive: false });
+}
+
+function applyTransform(g, translate, scale) {
+  g.setAttribute('transform', `translate(${translate.x},${translate.y}) scale(${scale})`);
+}
+
+function highlightNode(nodeId, edgeGroup, nodeGroup) {
+  for (const el of edgeGroup.querySelectorAll('.rg-edge, .rg-edge-label')) {
+    if (el.dataset.nodeId === nodeId) {
+      el.setAttribute('stroke-opacity', '1');
+      el.setAttribute('fill-opacity', '1');
+    } else {
+      el.setAttribute('stroke-opacity', '0.1');
+      el.setAttribute('fill-opacity', '0.1');
+    }
+  }
+  for (const el of nodeGroup.querySelectorAll('.rg-node')) {
+    el.setAttribute('opacity', el.dataset.nodeId === nodeId ? '1' : '0.3');
+  }
+}
+
+function clearHighlight(edgeGroup, nodeGroup) {
+  for (const el of edgeGroup.querySelectorAll('.rg-edge')) {
+    el.setAttribute('stroke-opacity', '0.4');
+  }
+  for (const el of edgeGroup.querySelectorAll('.rg-edge-label')) {
+    el.setAttribute('fill-opacity', '0.6');
+  }
+  for (const el of nodeGroup.querySelectorAll('.rg-node')) {
+    el.setAttribute('opacity', '1');
+  }
+}
+
+export function clearRelationshipGraph(container) {
+  container.innerHTML = '';
+}

--- a/app/renderer/modules/relationship-graph.js
+++ b/app/renderer/modules/relationship-graph.js
@@ -7,6 +7,8 @@ const RINGS = {
   hostile:  { r: 330, color: '#e57373', edgeColor: '#e57373' },
 };
 
+let panAbort = null;
+
 const CENTER_X = 300;
 const CENTER_Y = 300;
 const VIEWBOX = '0 0 600 600';
@@ -92,7 +94,7 @@ export function renderRelationshipGraph(container, litrpgState) {
 
   const chars = Object.values(litrpgState.characters || {});
   if (!chars.length) {
-    container.innerHTML = '<p style="color:#666;font-size:12px;padding:16px;text-align:center;">No characters found. Run a LitRPG scan first.</p>';
+    container.innerHTML = '<p class="rg-empty">No characters found. Run a LitRPG scan first.</p>';
     return;
   }
 
@@ -101,7 +103,6 @@ export function renderRelationshipGraph(container, litrpgState) {
   svg.setAttribute('viewBox', VIEWBOX);
   svg.setAttribute('width', '100%');
   svg.setAttribute('height', '100%');
-  svg.style.cssText = 'display:block;user-select:none;';
 
   // Inner transform group (for pan/zoom)
   const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
@@ -179,7 +180,6 @@ export function renderRelationshipGraph(container, litrpgState) {
     circle.setAttribute('fill', node.color);
     circle.setAttribute('stroke', '#1a1a2e');
     circle.setAttribute('stroke-width', '2');
-    circle.style.cursor = 'pointer';
     circle.dataset.nodeId = node.id;
     circle.classList.add('rg-node');
     nodeGroup.appendChild(circle);
@@ -299,6 +299,10 @@ export function renderRelationshipGraph(container, litrpgState) {
   });
 
   // --- Pan + Zoom ---
+  if (panAbort) panAbort.abort();
+  panAbort = new AbortController();
+  const { signal } = panAbort;
+
   let panActive = false;
   let panStart = { x: 0, y: 0 };
   let translate = { x: 0, y: 0 };
@@ -309,22 +313,22 @@ export function renderRelationshipGraph(container, litrpgState) {
     panActive = true;
     panStart = { x: e.clientX - translate.x, y: e.clientY - translate.y };
     svg.style.cursor = 'grabbing';
-  });
+  }, { signal });
   window.addEventListener('mousemove', (e) => {
     if (!panActive) return;
     translate.x = e.clientX - panStart.x;
     translate.y = e.clientY - panStart.y;
     applyTransform(g, translate, scale);
-  });
+  }, { signal });
   window.addEventListener('mouseup', () => {
     if (panActive) { panActive = false; svg.style.cursor = ''; }
-  });
+  }, { signal });
   svg.addEventListener('wheel', (e) => {
     e.preventDefault();
     const delta = e.deltaY > 0 ? -0.1 : 0.1;
     scale = Math.max(0.5, Math.min(2.0, scale + delta));
     applyTransform(g, translate, scale);
-  }, { passive: false });
+  }, { passive: false, signal });
 }
 
 function applyTransform(g, translate, scale) {
@@ -359,5 +363,6 @@ function clearHighlight(edgeGroup, nodeGroup) {
 }
 
 export function clearRelationshipGraph(container) {
+  if (panAbort) { panAbort.abort(); panAbort = null; }
   container.innerHTML = '';
 }

--- a/app/renderer/styles/main.css
+++ b/app/renderer/styles/main.css
@@ -4094,6 +4094,14 @@
     .rpg-action-bar-v2 .rpg-action-btn:hover { background: #3a3a6e; color: #e0e0e0; }
 
     /* Relationship Graph */
+    .relationship-graph-container svg { display: block; user-select: none; }
+    .rg-node { cursor: pointer; }
+    .rg-empty {
+      color: #666;
+      font-size: 12px;
+      padding: 16px;
+      text-align: center;
+    }
     .relationship-graph-container {
       width: 100%;
       height: 420px;
@@ -5205,6 +5213,12 @@
     .history-del-btn:hover {
       border-color: #e94560;
       color: #e94560;
+    }
+
+    .history-empty {
+      color: #666;
+      font-size: 12px;
+      padding: 8px 0;
     }
 
     /* Timeline cards */

--- a/app/renderer/styles/main.css
+++ b/app/renderer/styles/main.css
@@ -4081,6 +4081,41 @@
     }
     .rpg-action-bar-v2 .rpg-btn-primary.scanning .rpg-btn-spinner { display: inline-block; }
     .rpg-action-bar-v2 .rpg-btn-primary.scanning .rpg-btn-icon { display: none; }
+    .rpg-action-bar-v2 .rpg-action-btn {
+      background: #2a2a4e;
+      border: 1px solid #3a3a6e;
+      color: #ccc;
+      font-size: 11px;
+      padding: 4px 10px;
+      border-radius: 4px;
+      cursor: pointer;
+      white-space: nowrap;
+    }
+    .rpg-action-bar-v2 .rpg-action-btn:hover { background: #3a3a6e; color: #e0e0e0; }
+
+    /* Relationship Graph */
+    .relationship-graph-container {
+      width: 100%;
+      height: 420px;
+      overflow: hidden;
+      position: relative;
+      cursor: grab;
+      background: #0d0d1e;
+      border-bottom: 1px solid #2a2a4e;
+    }
+    .rg-tooltip {
+      position: absolute;
+      background: #16213e;
+      border: 1px solid #3a3a6e;
+      border-radius: 6px;
+      padding: 8px 10px;
+      font-size: 11px;
+      color: #ccc;
+      line-height: 1.5;
+      pointer-events: none;
+      max-width: 180px;
+      z-index: 10;
+    }
 
     /* Quest improvements (Phase 4.4) */
     .rpg-quest-card-v2 {

--- a/app/renderer/styles/main.css
+++ b/app/renderer/styles/main.css
@@ -5077,6 +5077,101 @@
       color: #e0e0e0;
     }
 
+    /* Prompt History */
+    .history-toolbar {
+      display: flex;
+      align-items: center;
+      padding: 8px 12px 4px;
+      gap: 8px;
+    }
+    .history-filter-btn {
+      background: none;
+      border: 1px solid #2a2a4e;
+      color: #888;
+      font-size: 11px;
+      padding: 3px 8px;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+    .history-filter-btn.active {
+      border-color: #e94560;
+      color: #e94560;
+    }
+    .history-list {
+      padding: 4px 12px 12px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      overflow-y: auto;
+      max-height: calc(100vh - 160px);
+    }
+    .history-card {
+      background: #16213e;
+      border: 1px solid #2a2a4e;
+      border-radius: 6px;
+      padding: 10px 12px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+    .history-card-header {
+      display: flex;
+      align-items: flex-start;
+      gap: 8px;
+    }
+    .history-prompt-text {
+      flex: 1;
+      font-size: 12px;
+      color: #c0c0c0;
+      line-height: 1.4;
+      word-break: break-word;
+    }
+    .history-star {
+      background: none;
+      border: none;
+      cursor: pointer;
+      font-size: 16px;
+      color: #444;
+      padding: 0;
+      line-height: 1;
+      flex-shrink: 0;
+    }
+    .history-star.fav {
+      color: #e9c846;
+    }
+    .history-card-footer {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+    .history-meta {
+      flex: 1;
+      font-size: 10px;
+      color: #555;
+    }
+    .history-reuse-btn {
+      background: #e94560;
+      border: none;
+      color: white;
+      font-size: 11px;
+      padding: 3px 8px;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+    .history-del-btn {
+      background: none;
+      border: 1px solid #2a2a4e;
+      color: #666;
+      font-size: 11px;
+      padding: 3px 8px;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+    .history-del-btn:hover {
+      border-color: #e94560;
+      color: #e94560;
+    }
+
     /* Timeline cards */
     .timeline-chapter {
       margin-bottom: 12px;


### PR DESCRIPTION
## Summary

- **#20 Prompt History with Favorites** — Auto-saves every generated prompt to a per-story SQLite history (50-entry cap, oldest non-favorites pruned). New History sub-tab in the Scene panel shows cards with truncated prompt text, timestamp, provider/model badge, star (favorites), Reuse, and Delete. Reuse loads the prompt back into the prompt textarea and switches to the Storyboard tab.

- **#21 Character Relationship Graph** — Pure SVG radial graph in the Cast panel (no external library). Protagonist at center; characters arranged in concentric rings by disposition (party → friendly → neutral → hostile). Faction hub nodes connect characters sharing a faction. Edge labels show `npcRole`/`partyRole`. Hover tooltip, click-to-highlight, pan, and zoom (0.5–2×). Toggled via a "Graph" button in the RPG action bar; button only appears when LitRPG is enabled with characters.

## Files changed

**#20:**
- `app/db.js` — `prompt_history` table + 4 CRUD functions
- `app/main.js` — 4 IPC handlers
- `app/preload.js` — 4 bridge methods
- `app/renderer/index.html` + `main.css` — History sub-tab + card CSS
- `app/renderer/modules/prompt-history.js` — new module
- `app/renderer/modules/lore-creator.js` + `dom-refs.js` — tab switching wired

**#21:**
- `app/renderer/modules/relationship-graph.js` — new SVG graph module
- `app/renderer/index.html` + `main.css` — graph container + CSS
- `app/renderer/modules/litrpg-panel.js` + `dom-refs.js` — toggle wiring

## Test plan

- [ ] Generate an image → History sub-tab shows the entry
- [ ] Star an entry → moves to top, star fills; Favorites filter works
- [ ] Click Reuse → prompt textarea fills, tab switches to Storyboard
- [ ] Generate 51 images → only 50 entries (oldest non-favorite pruned)
- [ ] Open Cast panel with 3+ LitRPG characters → Graph button appears
- [ ] Click Graph → SVG renders with protagonist at center and character rings
- [ ] Hover a node → tooltip shows name, class/level, faction, relationship
- [ ] Click a node → its edges highlight, others dim; click background to reset
- [ ] Switch stories → graph resets to list view